### PR TITLE
EN-5448: Remove use of client_id for requests

### DIFF
--- a/fhirclient/auth.py
+++ b/fhirclient/auth.py
@@ -308,7 +308,7 @@ class FHIROAuth2Auth(FHIRAuth):
         access token.
         """
         params = {
-            'client_id': self.app_id,
+            # 'client_id': self.app_id,         # Its being dynamically added only for epic
             'code': code,
             'grant_type': 'authorization_code',
             'redirect_uri': self._redirect_uri,
@@ -476,7 +476,7 @@ class FHIROAuth2Auth(FHIRAuth):
         if self.refresh_token is None:
             raise Exception("Cannot produce reauthorize parameters without refresh token")
         return {
-            'client_id': self.app_id,
+            # 'client_id': self.app_id,         # Its being dynamically added only for epic
             #'client_secret': None,             # we don't use it
             'grant_type': 'refresh_token',
             'refresh_token': self.refresh_token,

--- a/fhirclient/client.py
+++ b/fhirclient/client.py
@@ -1,7 +1,7 @@
 import logging
 from .server import FHIRServer, FHIRUnauthorizedException, FHIRNotFoundException
 
-__version__ = '4.3.1+unite.7'
+__version__ = '4.3.1+unite.8'
 __author__ = 'SMART Platforms Team'
 __license__ = 'APACHE2'
 __copyright__ = "Copyright 2017 Boston Children's Hospital"


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove the use of `client_id` from request parameters in `fhirclient/auth.py` and update the module version to `4.3.1+unite.8`.

### Why are these changes being made?

These changes were made to eliminate the hardcoded use of `client_id` in authentication requests, as it's only dynamically required for specific cases with certain providers such as Epic. This helps streamline code and avoid unnecessary parameters where not needed.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->