### PR TITLE
EN-6405 Add scope to JWT bearer token request

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "SMART on FHIR Python Client"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "4.4.0+unite.1"
+PROJECT_NUMBER         = "4.4.0+unite.2"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/fhirclient/auth.py
+++ b/fhirclient/auth.py
@@ -407,6 +407,8 @@ class FHIROAuth2Auth(FHIRAuth):
             "client_id": self.client_id,
             "assertion": signed_jwt,
         }
+        if server.desired_scope:
+            payload["scope"] = server.desired_scope
 
         res = server.session.post(self._token_uri, headers=headers, data=payload)
         server.raise_for_status(res)

--- a/fhirclient/client.py
+++ b/fhirclient/client.py
@@ -1,7 +1,7 @@
 import logging
 from .server import FHIRServer, FHIRUnauthorizedException, FHIRNotFoundException
 
-__version__ = "4.4.0+unite.1"  # Update docs/Doxyfile too when you bump this
+__version__ = "4.4.0+unite.2"  # Update docs/Doxyfile too when you bump this
 __author__ = "SMART Platforms Team"
 __license__ = "APACHE2"
 __copyright__ = "Copyright 2017 Boston Children's Hospital"


### PR DESCRIPTION
## Summary
- Include `desired_scope` in the OAuth2 JWT bearer grant token request payload
- When `server.desired_scope` is set, the `scope` parameter is now sent in the token request, ensuring the issued token has the correct scopes

## Test plan
- [ ] Verify OAuth2 JWT bearer flow requests a token with the expected scopes
- [ ] Confirm no regression when `desired_scope` is not set (scope param is omitted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)