### PR TITLE
EN-7067 Add .well-known/smart-configuration fallback for OAuth discovery

### DIFF
--- a/fhirclient/auth.py
+++ b/fhirclient/auth.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, timezone
 import urllib.parse as urlparse
 from urllib.parse import urlencode
 
-import requests as _requests_lib
+import requests
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives._serialization import Encoding, PublicFormat
 from jwt.algorithms import RSAAlgorithm
@@ -121,7 +121,7 @@ class FHIRAuth:
         well_known_url = aud.rstrip("/") + "/.well-known/smart-configuration"
 
         try:
-            resp = _requests_lib.get(
+            resp = requests.get(
                 well_known_url,
                 headers={"Accept": "application/json"},
                 timeout=10,
@@ -129,7 +129,7 @@ class FHIRAuth:
             resp.raise_for_status()
             wk = resp.json()
         except Exception as e:
-            logger.debug(f"SMART AUTH: .well-known discovery failed for {aud}: {e}")
+            logger.info(f"SMART AUTH: .well-known discovery failed for {aud}: {e}")
             return None
 
         authorize_uri = wk.get("authorization_endpoint")

--- a/fhirclient/auth.py
+++ b/fhirclient/auth.py
@@ -8,6 +8,8 @@ import secrets
 from datetime import datetime, timedelta, timezone
 import urllib.parse as urlparse
 from urllib.parse import urlencode
+
+import requests as _requests_lib
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives._serialization import Encoding, PublicFormat
 from jwt.algorithms import RSAAlgorithm
@@ -90,7 +92,62 @@ class FHIRAuth:
             ):
                 auth_type = "oauth2"
 
+        # Fallback: if CapabilityStatement had no security block (or no OAuth
+        # extensions), try .well-known/smart-configuration before giving up.
+        # Some FHIR servers (e.g. Elevance Health) don't advertise OAuth in
+        # their CapabilityStatement but do support it via .well-known.
+        if auth_type is None and state and state.get("aud"):
+            auth_type = cls._try_well_known_discovery(state)
+
         return cls.create(auth_type, state=state)
+
+    @classmethod
+    def _try_well_known_discovery(cls, state):
+        """Try to discover OAuth endpoints from .well-known/smart-configuration.
+
+        Called as a fallback when the CapabilityStatement has no security block.
+        Some FHIR servers (e.g. Elevance Health) advertise OAuth via
+        .well-known but not in their CapabilityStatement.
+
+        :param state: A settings/state dictionary (must contain 'aud')
+        :returns: 'oauth2' if discovery succeeds, None otherwise
+
+        Note: This uses requests.get() directly rather than server.session
+        because no server instance is available at this point in the flow.
+        This means the request won't inherit proxy, cert bundle, or retry
+        config from the server session.
+        """
+        aud = state["aud"]
+        well_known_url = aud.rstrip("/") + "/.well-known/smart-configuration"
+
+        try:
+            resp = _requests_lib.get(
+                well_known_url,
+                headers={"Accept": "application/json"},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            wk = resp.json()
+        except Exception as e:
+            logger.debug(f"SMART AUTH: .well-known discovery failed for {aud}: {e}")
+            return None
+
+        authorize_uri = wk.get("authorization_endpoint")
+        token_uri = wk.get("token_endpoint")
+
+        if authorize_uri and token_uri:
+            state["authorize_uri"] = authorize_uri
+            state["token_uri"] = token_uri
+            if "registration_endpoint" in wk:
+                state["registration_uri"] = wk["registration_endpoint"]
+            # Cache the full .well-known response so _authorize_params()
+            # can reuse it for PKCE discovery without a second fetch.
+            state["well_known_config"] = wk
+            logger.info(f"SMART AUTH: Discovered OAuth endpoints via .well-known for {aud}")
+            return "oauth2"
+
+        logger.debug(f"SMART AUTH: .well-known for {aud} missing authorize/token endpoints")
+        return None
 
     @classmethod
     def create(cls, auth_type, state=None):
@@ -179,6 +236,7 @@ class FHIROAuth2Auth(FHIRAuth):
 
         self.code_verifier = None
         self.code_challenge = None
+        self._well_known_config = None
 
         super(FHIROAuth2Auth, self).__init__(state=state)
 
@@ -259,21 +317,26 @@ class FHIROAuth2Auth(FHIRAuth):
         if server.launch_token is not None:
             params['launch'] = server.launch_token
 
-        try:
-            smart_configuration_url = self.aud
-            if self.aud.endswith('/'):
-                smart_configuration_url = self.aud[:-1]
+        # Use cached .well-known config from discovery if available,
+        # otherwise fetch it fresh.
+        if self._well_known_config is not None:
+            smart_configuration = self._well_known_config
+        else:
+            try:
+                smart_configuration_url = self.aud
+                if self.aud.endswith('/'):
+                    smart_configuration_url = self.aud[:-1]
 
-            smart_configuration_url += '/.well-known/smart-configuration'
-            response = server.request_data(smart_configuration_url)
+                smart_configuration_url += '/.well-known/smart-configuration'
+                response = server.request_data(smart_configuration_url)
 
-            smart_configuration = json.loads(response.decode('utf-8'))
-        except (ValueError, json.JSONDecodeError) as e:
-            logger.warning(f"Failed to parse SMART configuration: {e}")
-            smart_configuration = None
-        except Exception as e:
-            logger.warning(f"Failed to fetch SMART configuration: {e}")
-            smart_configuration = None
+                smart_configuration = json.loads(response.decode('utf-8'))
+            except (ValueError, json.JSONDecodeError) as e:
+                logger.warning(f"Failed to parse SMART configuration: {e}")
+                smart_configuration = None
+            except Exception as e:
+                logger.warning(f"Failed to fetch SMART configuration: {e}")
+                smart_configuration = None
 
         if self._supports_pkce_s256(smart_configuration):
             challenge = generate_pkce_challenge()
@@ -592,6 +655,12 @@ class FHIROAuth2Auth(FHIRAuth):
 
         self.code_verifier = state.get('code_verifier') or self.code_verifier
         self.code_challenge = state.get('code_challenge') or self.code_challenge
+        # _well_known_config is a transient in-memory cache populated at
+        # initial creation via from_capability_security(). It is intentionally
+        # NOT included in the state property (write side) so it won't be
+        # serialized/persisted. On deserialization it will be None, and
+        # _authorize_params() will fall back to fetching .well-known fresh.
+        self._well_known_config = state.get('well_known_config') or self._well_known_config
 
     # MARK: Utilities
 

--- a/fhirclient/auth.py
+++ b/fhirclient/auth.py
@@ -322,7 +322,8 @@ class FHIROAuth2Auth(FHIRAuth):
         if self._well_known_config is not None:
             logger.warning(
                 "SMART AUTH: CapabilityStatement for %s had no OAuth endpoints; "
-                "using cached .well-known/smart-configuration for PKCE discovery",
+                "using cached .well-known/smart-configuration for PKCE discovery "
+                "(fetched via direct HTTP GET, bypassing server session proxy/cert config)",
                 self.aud,
             )
             smart_configuration = self._well_known_config

--- a/fhirclient/auth.py
+++ b/fhirclient/auth.py
@@ -320,6 +320,11 @@ class FHIROAuth2Auth(FHIRAuth):
         # Use cached .well-known config from discovery if available,
         # otherwise fetch it fresh.
         if self._well_known_config is not None:
+            logger.warning(
+                "SMART AUTH: CapabilityStatement for %s had no OAuth endpoints; "
+                "using cached .well-known/smart-configuration for PKCE discovery",
+                self.aud,
+            )
             smart_configuration = self._well_known_config
         else:
             try:

--- a/fhirclient/auth.py
+++ b/fhirclient/auth.py
@@ -38,13 +38,23 @@ class FHIRAuth:
                 f'Class {FHIRAuth.auth_classes[cls.auth_type]} is already registered for authorization type "{cls.auth_type}"'
             )
 
+    @staticmethod
+    def _well_known_url(aud):
+        """Build the .well-known/smart-configuration URL for a given aud.
+
+        :param str aud: The FHIR server base URL
+        :returns: The .well-known URL
+        """
+        return aud.rstrip("/") + "/.well-known/smart-configuration"
+
     @classmethod
-    def from_capability_security(cls, security, state=None):
+    def from_capability_security(cls, security, state=None, session=None):
         """Supply a capabilitystatement.rest.security statement and this
         method will figure out which type of security should be instantiated.
 
         :param security: A CapabilityStatementRestSecurity instance
         :param state: A settings/state dictionary
+        :param session: An optional requests.Session for HTTP calls
         :returns: A FHIRAuth instance or subclass thereof
         """
         auth_type = None
@@ -97,12 +107,12 @@ class FHIRAuth:
         # Some FHIR servers (e.g. Elevance Health) don't advertise OAuth in
         # their CapabilityStatement but do support it via .well-known.
         if auth_type is None and state and state.get("aud"):
-            auth_type = cls._try_well_known_discovery(state)
+            auth_type = cls._try_well_known_discovery(state, session=session)
 
         return cls.create(auth_type, state=state)
 
     @classmethod
-    def _try_well_known_discovery(cls, state):
+    def _try_well_known_discovery(cls, state, session=None):
         """Try to discover OAuth endpoints from .well-known/smart-configuration.
 
         Called as a fallback when the CapabilityStatement has no security block.
@@ -110,18 +120,17 @@ class FHIRAuth:
         .well-known but not in their CapabilityStatement.
 
         :param state: A settings/state dictionary (must contain 'aud')
+        :param session: An optional requests.Session to use for the HTTP call.
+            When provided, the request inherits the session's proxy, cert
+            bundle, and retry config.
         :returns: 'oauth2' if discovery succeeds, None otherwise
-
-        Note: This uses requests.get() directly rather than server.session
-        because no server instance is available at this point in the flow.
-        This means the request won't inherit proxy, cert bundle, or retry
-        config from the server session.
         """
         aud = state["aud"]
-        well_known_url = aud.rstrip("/") + "/.well-known/smart-configuration"
+        well_known_url = cls._well_known_url(aud)
+        http = session or requests
 
         try:
-            resp = requests.get(
+            resp = http.get(
                 well_known_url,
                 headers={"Accept": "application/json"},
                 timeout=10,
@@ -320,20 +329,15 @@ class FHIROAuth2Auth(FHIRAuth):
         # Use cached .well-known config from discovery if available,
         # otherwise fetch it fresh.
         if self._well_known_config is not None:
-            logger.warning(
-                "SMART AUTH: CapabilityStatement for %s had no OAuth endpoints; "
-                "using cached .well-known/smart-configuration for PKCE discovery "
-                "(fetched via direct HTTP GET, bypassing server session proxy/cert config)",
+            logger.info(
+                "SMART AUTH: Using cached .well-known/smart-configuration "
+                "for PKCE discovery for %s",
                 self.aud,
             )
             smart_configuration = self._well_known_config
         else:
             try:
-                smart_configuration_url = self.aud
-                if self.aud.endswith('/'):
-                    smart_configuration_url = self.aud[:-1]
-
-                smart_configuration_url += '/.well-known/smart-configuration'
+                smart_configuration_url = FHIRAuth._well_known_url(self.aud)
                 response = server.request_data(smart_configuration_url)
 
                 smart_configuration = json.loads(response.decode('utf-8'))

--- a/fhirclient/client.py
+++ b/fhirclient/client.py
@@ -1,7 +1,7 @@
 import logging
 from .server import FHIRServer, FHIRUnauthorizedException, FHIRNotFoundException
 
-__version__ = "4.4.0+unite.2"  # Update docs/Doxyfile too when you bump this
+__version__ = "4.4.0+unite.3"  # Update docs/Doxyfile too when you bump this
 __author__ = "SMART Platforms Team"
 __license__ = "APACHE2"
 __copyright__ = "Copyright 2017 Boston Children's Hospital"

--- a/fhirclient/client.py
+++ b/fhirclient/client.py
@@ -28,6 +28,7 @@ class FHIRClient:
         - `launch_token`: The launch token
         - `capability_callback`: Callable(base_uri) -> CapabilityStatement or None, for external caching
         - `on_capability_fetched`: Callable(base_uri, CapabilityStatement) -> None, called after network fetch
+
     """
     def __init__(self, settings=None, state=None, save_func=lambda x: x, load_func=lambda x: None):
         self.app_id = None

--- a/fhirclient/server.py
+++ b/fhirclient/server.py
@@ -133,7 +133,7 @@ class FHIRServer(object):
                 else None,
                 "jwt_token": self.client.jwt_token if self.client is not None else None,
             }
-            self.auth = FHIRAuth.from_capability_security(security, settings)
+            self.auth = FHIRAuth.from_capability_security(security, settings, session=self.session)
             self.should_save_state()
 
     # MARK: Authorization

--- a/tests/auth_test.py
+++ b/tests/auth_test.py
@@ -1,0 +1,203 @@
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from fhirclient.auth import FHIRAuth, FHIROAuth2Auth
+
+
+class TestWellKnownDiscovery(unittest.TestCase):
+    """Tests for .well-known/smart-configuration fallback discovery."""
+
+    def _make_state(self, aud="https://fhir.example.com/api/v1/fhir"):
+        return {
+            "aud": aud,
+            "app_id": "test-client-id",
+            "app_secret": None,
+            "redirect_uri": "https://example.com/callback",
+            "jwt_token": None,
+        }
+
+    def _well_known_response(self, authorize=True, token=True, registration=False):
+        wk = {}
+        if authorize:
+            wk["authorization_endpoint"] = "https://fhir.example.com/oauth2/authorize"
+        if token:
+            wk["token_endpoint"] = "https://fhir.example.com/oauth2/token"
+        if registration:
+            wk["registration_endpoint"] = "https://fhir.example.com/oauth2/register"
+        wk["code_challenge_methods_supported"] = ["S256"]
+        return wk
+
+    @patch("fhirclient.auth._requests_lib.get")
+    def test_discovery_creates_oauth2_when_security_is_none(self, mock_get):
+        """When CapabilityStatement has no security, .well-known should be tried
+        and FHIROAuth2Auth should be created."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = self._well_known_response()
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        state = self._make_state()
+        auth = FHIRAuth.from_capability_security(None, state)
+
+        self.assertIsInstance(auth, FHIROAuth2Auth)
+        self.assertEqual(state["authorize_uri"], "https://fhir.example.com/oauth2/authorize")
+        self.assertEqual(state["token_uri"], "https://fhir.example.com/oauth2/token")
+        mock_get.assert_called_once()
+
+    @patch("fhirclient.auth._requests_lib.get")
+    def test_discovery_includes_registration_uri(self, mock_get):
+        """registration_endpoint from .well-known should be stored in state."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = self._well_known_response(registration=True)
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        state = self._make_state()
+        auth = FHIRAuth.from_capability_security(None, state)
+
+        self.assertIsInstance(auth, FHIROAuth2Auth)
+        self.assertEqual(state["registration_uri"], "https://fhir.example.com/oauth2/register")
+
+    @patch("fhirclient.auth._requests_lib.get")
+    def test_discovery_falls_back_to_basic_on_network_error(self, mock_get):
+        """Network errors should not raise — fall back to basic FHIRAuth."""
+        mock_get.side_effect = Exception("Connection refused")
+
+        state = self._make_state()
+        auth = FHIRAuth.from_capability_security(None, state)
+
+        self.assertNotIsInstance(auth, FHIROAuth2Auth)
+        self.assertEqual(auth.auth_type, "none")
+
+    @patch("fhirclient.auth._requests_lib.get")
+    def test_discovery_falls_back_when_missing_endpoints(self, mock_get):
+        """If .well-known response lacks authorize or token, fall back."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = self._well_known_response(authorize=True, token=False)
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        state = self._make_state()
+        auth = FHIRAuth.from_capability_security(None, state)
+
+        self.assertNotIsInstance(auth, FHIROAuth2Auth)
+
+    @patch("fhirclient.auth._requests_lib.get")
+    def test_discovery_falls_back_on_http_error(self, mock_get):
+        """HTTP 404 from .well-known should not raise — fall back."""
+        import requests
+
+        mock_get.side_effect = requests.HTTPError("404 Not Found")
+
+        state = self._make_state()
+        auth = FHIRAuth.from_capability_security(None, state)
+
+        self.assertNotIsInstance(auth, FHIROAuth2Auth)
+
+    @patch("fhirclient.auth._requests_lib.get")
+    def test_discovery_caches_well_known_config(self, mock_get):
+        """The .well-known response should be cached in state for reuse."""
+        wk = self._well_known_response()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = wk
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        state = self._make_state()
+        FHIRAuth.from_capability_security(None, state)
+
+        self.assertEqual(state["well_known_config"], wk)
+
+    @patch("fhirclient.auth._requests_lib.get")
+    def test_discovery_not_called_when_security_has_oauth(self, mock_get):
+        """When CapabilityStatement has OAuth extensions, .well-known should NOT be fetched."""
+        security = MagicMock()
+        ext_inner = MagicMock()
+        ext_inner.url = "token"
+        ext_inner.valueUri = "https://fhir.example.com/oauth2/token"
+        ext_inner2 = MagicMock()
+        ext_inner2.url = "authorize"
+        ext_inner2.valueUri = "https://fhir.example.com/oauth2/authorize"
+
+        ext = MagicMock()
+        ext.url = "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris"
+        ext.extension = [ext_inner, ext_inner2]
+        security.extension = [ext]
+
+        state = self._make_state()
+        auth = FHIRAuth.from_capability_security(security, state)
+
+        self.assertIsInstance(auth, FHIROAuth2Auth)
+        mock_get.assert_not_called()
+
+    def test_discovery_skipped_when_no_aud(self):
+        """If state has no aud, .well-known should not be attempted."""
+        state = {"app_id": "test"}
+        auth = FHIRAuth.from_capability_security(None, state)
+
+        self.assertNotIsInstance(auth, FHIROAuth2Auth)
+
+    @patch("fhirclient.auth._requests_lib.get")
+    def test_discovery_strips_trailing_slash_from_aud(self, mock_get):
+        """Trailing slash on aud should not produce double-slash in .well-known URL."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = self._well_known_response()
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        state = self._make_state(aud="https://fhir.example.com/api/v1/fhir/")
+        FHIRAuth.from_capability_security(None, state)
+
+        called_url = mock_get.call_args[0][0]
+        self.assertEqual(
+            called_url,
+            "https://fhir.example.com/api/v1/fhir/.well-known/smart-configuration",
+        )
+        self.assertNotIn("//.", called_url)
+
+
+class TestWellKnownCacheInAuthorizeParams(unittest.TestCase):
+    """Tests that cached .well-known config is reused in _authorize_params."""
+
+    @patch("fhirclient.auth._requests_lib.get")
+    def test_cached_config_prevents_second_fetch(self, mock_get):
+        """When _well_known_config is set, _authorize_params should not re-fetch."""
+        wk = {
+            "authorization_endpoint": "https://fhir.example.com/oauth2/authorize",
+            "token_endpoint": "https://fhir.example.com/oauth2/token",
+            "code_challenge_methods_supported": ["S256"],
+        }
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = wk
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        state = self._make_state()
+        auth = FHIRAuth.from_capability_security(None, state)
+
+        # Reset mock to track only _authorize_params calls
+        mock_get.reset_mock()
+
+        server = MagicMock()
+        server.desired_scope = "patient/*.read"
+        server.launch_token = None
+
+        auth._authorize_params(server)
+
+        # .well-known should NOT have been fetched again
+        mock_get.assert_not_called()
+        server.request_data.assert_not_called()
+
+    def _make_state(self, aud="https://fhir.example.com/api/v1/fhir"):
+        return {
+            "aud": aud,
+            "app_id": "test-client-id",
+            "app_secret": None,
+            "redirect_uri": "https://example.com/callback",
+            "jwt_token": None,
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/auth_test.py
+++ b/tests/auth_test.py
@@ -28,7 +28,7 @@ class TestWellKnownDiscovery(unittest.TestCase):
         wk["code_challenge_methods_supported"] = ["S256"]
         return wk
 
-    @patch("fhirclient.auth._requests_lib.get")
+    @patch("fhirclient.auth.requests.get")
     def test_discovery_creates_oauth2_when_security_is_none(self, mock_get):
         """When CapabilityStatement has no security, .well-known should be tried
         and FHIROAuth2Auth should be created."""
@@ -45,7 +45,7 @@ class TestWellKnownDiscovery(unittest.TestCase):
         self.assertEqual(state["token_uri"], "https://fhir.example.com/oauth2/token")
         mock_get.assert_called_once()
 
-    @patch("fhirclient.auth._requests_lib.get")
+    @patch("fhirclient.auth.requests.get")
     def test_discovery_includes_registration_uri(self, mock_get):
         """registration_endpoint from .well-known should be stored in state."""
         mock_resp = MagicMock()
@@ -59,7 +59,7 @@ class TestWellKnownDiscovery(unittest.TestCase):
         self.assertIsInstance(auth, FHIROAuth2Auth)
         self.assertEqual(state["registration_uri"], "https://fhir.example.com/oauth2/register")
 
-    @patch("fhirclient.auth._requests_lib.get")
+    @patch("fhirclient.auth.requests.get")
     def test_discovery_falls_back_to_basic_on_network_error(self, mock_get):
         """Network errors should not raise — fall back to basic FHIRAuth."""
         mock_get.side_effect = Exception("Connection refused")
@@ -70,7 +70,7 @@ class TestWellKnownDiscovery(unittest.TestCase):
         self.assertNotIsInstance(auth, FHIROAuth2Auth)
         self.assertEqual(auth.auth_type, "none")
 
-    @patch("fhirclient.auth._requests_lib.get")
+    @patch("fhirclient.auth.requests.get")
     def test_discovery_falls_back_when_missing_endpoints(self, mock_get):
         """If .well-known response lacks authorize or token, fall back."""
         mock_resp = MagicMock()
@@ -83,7 +83,7 @@ class TestWellKnownDiscovery(unittest.TestCase):
 
         self.assertNotIsInstance(auth, FHIROAuth2Auth)
 
-    @patch("fhirclient.auth._requests_lib.get")
+    @patch("fhirclient.auth.requests.get")
     def test_discovery_falls_back_on_http_error(self, mock_get):
         """HTTP 404 from .well-known should not raise — fall back."""
         import requests
@@ -95,7 +95,7 @@ class TestWellKnownDiscovery(unittest.TestCase):
 
         self.assertNotIsInstance(auth, FHIROAuth2Auth)
 
-    @patch("fhirclient.auth._requests_lib.get")
+    @patch("fhirclient.auth.requests.get")
     def test_discovery_caches_well_known_config(self, mock_get):
         """The .well-known response should be cached in state for reuse."""
         wk = self._well_known_response()
@@ -109,7 +109,7 @@ class TestWellKnownDiscovery(unittest.TestCase):
 
         self.assertEqual(state["well_known_config"], wk)
 
-    @patch("fhirclient.auth._requests_lib.get")
+    @patch("fhirclient.auth.requests.get")
     def test_discovery_not_called_when_security_has_oauth(self, mock_get):
         """When CapabilityStatement has OAuth extensions, .well-known should NOT be fetched."""
         security = MagicMock()
@@ -138,7 +138,7 @@ class TestWellKnownDiscovery(unittest.TestCase):
 
         self.assertNotIsInstance(auth, FHIROAuth2Auth)
 
-    @patch("fhirclient.auth._requests_lib.get")
+    @patch("fhirclient.auth.requests.get")
     def test_discovery_strips_trailing_slash_from_aud(self, mock_get):
         """Trailing slash on aud should not produce double-slash in .well-known URL."""
         mock_resp = MagicMock()
@@ -160,7 +160,7 @@ class TestWellKnownDiscovery(unittest.TestCase):
 class TestWellKnownCacheInAuthorizeParams(unittest.TestCase):
     """Tests that cached .well-known config is reused in _authorize_params."""
 
-    @patch("fhirclient.auth._requests_lib.get")
+    @patch("fhirclient.auth.requests.get")
     def test_cached_config_prevents_second_fetch(self, mock_get):
         """When _well_known_config is set, _authorize_params should not re-fetch."""
         wk = {
@@ -197,6 +197,35 @@ class TestWellKnownCacheInAuthorizeParams(unittest.TestCase):
             "redirect_uri": "https://example.com/callback",
             "jwt_token": None,
         }
+
+
+class TestWellKnownCacheNotSerialized(unittest.TestCase):
+    """Test that well_known_config is excluded from serialized state."""
+
+    @patch("fhirclient.auth.requests.get")
+    def test_well_known_config_not_in_state_property(self, mock_get):
+        """well_known_config should not appear in auth.state (write side)."""
+        wk = {
+            "authorization_endpoint": "https://fhir.example.com/oauth2/authorize",
+            "token_endpoint": "https://fhir.example.com/oauth2/token",
+            "code_challenge_methods_supported": ["S256"],
+        }
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = wk
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        state = {
+            "aud": "https://fhir.example.com/api/v1/fhir",
+            "app_id": "test-client-id",
+            "app_secret": None,
+            "redirect_uri": "https://example.com/callback",
+            "jwt_token": None,
+        }
+        auth = FHIRAuth.from_capability_security(None, state)
+
+        self.assertIsInstance(auth, FHIROAuth2Auth)
+        self.assertNotIn("well_known_config", auth.state)
 
 
 if __name__ == "__main__":

--- a/tests/auth_test.py
+++ b/tests/auth_test.py
@@ -15,7 +15,19 @@ class TestWellKnownDiscovery(unittest.TestCase):
             "app_secret": None,
             "redirect_uri": "https://example.com/callback",
             "jwt_token": None,
+
         }
+
+    def _make_session(self, wk_response=None, side_effect=None):
+        session = MagicMock()
+        if side_effect:
+            session.get.side_effect = side_effect
+        else:
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = wk_response
+            mock_resp.raise_for_status = MagicMock()
+            session.get.return_value = mock_resp
+        return session
 
     def _well_known_response(self, authorize=True, token=True, registration=False):
         wk = {}
@@ -28,89 +40,70 @@ class TestWellKnownDiscovery(unittest.TestCase):
         wk["code_challenge_methods_supported"] = ["S256"]
         return wk
 
-    @patch("fhirclient.auth.requests.get")
-    def test_discovery_creates_oauth2_when_security_is_none(self, mock_get):
+    def test_discovery_creates_oauth2_when_security_is_none(self):
         """When CapabilityStatement has no security, .well-known should be tried
         and FHIROAuth2Auth should be created."""
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = self._well_known_response()
-        mock_resp.raise_for_status = MagicMock()
-        mock_get.return_value = mock_resp
+        session = self._make_session(self._well_known_response())
 
         state = self._make_state()
-        auth = FHIRAuth.from_capability_security(None, state)
+        auth = FHIRAuth.from_capability_security(None, state, session=session)
 
         self.assertIsInstance(auth, FHIROAuth2Auth)
         self.assertEqual(state["authorize_uri"], "https://fhir.example.com/oauth2/authorize")
         self.assertEqual(state["token_uri"], "https://fhir.example.com/oauth2/token")
-        mock_get.assert_called_once()
+        session.get.assert_called_once()
 
-    @patch("fhirclient.auth.requests.get")
-    def test_discovery_includes_registration_uri(self, mock_get):
+    def test_discovery_includes_registration_uri(self):
         """registration_endpoint from .well-known should be stored in state."""
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = self._well_known_response(registration=True)
-        mock_resp.raise_for_status = MagicMock()
-        mock_get.return_value = mock_resp
+        session = self._make_session(self._well_known_response(registration=True))
 
         state = self._make_state()
-        auth = FHIRAuth.from_capability_security(None, state)
+        auth = FHIRAuth.from_capability_security(None, state, session=session)
 
         self.assertIsInstance(auth, FHIROAuth2Auth)
         self.assertEqual(state["registration_uri"], "https://fhir.example.com/oauth2/register")
 
-    @patch("fhirclient.auth.requests.get")
-    def test_discovery_falls_back_to_basic_on_network_error(self, mock_get):
+    def test_discovery_falls_back_to_basic_on_network_error(self):
         """Network errors should not raise — fall back to basic FHIRAuth."""
-        mock_get.side_effect = Exception("Connection refused")
+        session = self._make_session(side_effect=Exception("Connection refused"))
 
         state = self._make_state()
-        auth = FHIRAuth.from_capability_security(None, state)
+        auth = FHIRAuth.from_capability_security(None, state, session=session)
 
         self.assertNotIsInstance(auth, FHIROAuth2Auth)
         self.assertEqual(auth.auth_type, "none")
 
-    @patch("fhirclient.auth.requests.get")
-    def test_discovery_falls_back_when_missing_endpoints(self, mock_get):
+    def test_discovery_falls_back_when_missing_endpoints(self):
         """If .well-known response lacks authorize or token, fall back."""
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = self._well_known_response(authorize=True, token=False)
-        mock_resp.raise_for_status = MagicMock()
-        mock_get.return_value = mock_resp
+        session = self._make_session(self._well_known_response(authorize=True, token=False))
 
         state = self._make_state()
-        auth = FHIRAuth.from_capability_security(None, state)
+        auth = FHIRAuth.from_capability_security(None, state, session=session)
 
         self.assertNotIsInstance(auth, FHIROAuth2Auth)
 
-    @patch("fhirclient.auth.requests.get")
-    def test_discovery_falls_back_on_http_error(self, mock_get):
+    def test_discovery_falls_back_on_http_error(self):
         """HTTP 404 from .well-known should not raise — fall back."""
         import requests
 
-        mock_get.side_effect = requests.HTTPError("404 Not Found")
+        session = self._make_session(side_effect=requests.HTTPError("404 Not Found"))
 
         state = self._make_state()
-        auth = FHIRAuth.from_capability_security(None, state)
+        auth = FHIRAuth.from_capability_security(None, state, session=session)
 
         self.assertNotIsInstance(auth, FHIROAuth2Auth)
 
-    @patch("fhirclient.auth.requests.get")
-    def test_discovery_caches_well_known_config(self, mock_get):
+    def test_discovery_caches_well_known_config(self):
         """The .well-known response should be cached in state for reuse."""
         wk = self._well_known_response()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = wk
-        mock_resp.raise_for_status = MagicMock()
-        mock_get.return_value = mock_resp
+        session = self._make_session(wk)
 
         state = self._make_state()
-        FHIRAuth.from_capability_security(None, state)
+        FHIRAuth.from_capability_security(None, state, session=session)
 
         self.assertEqual(state["well_known_config"], wk)
 
-    @patch("fhirclient.auth.requests.get")
-    def test_discovery_not_called_when_security_has_oauth(self, mock_get):
+    def test_discovery_not_called_when_security_has_oauth(self):
         """When CapabilityStatement has OAuth extensions, .well-known should NOT be fetched."""
         security = MagicMock()
         ext_inner = MagicMock()
@@ -125,59 +118,81 @@ class TestWellKnownDiscovery(unittest.TestCase):
         ext.extension = [ext_inner, ext_inner2]
         security.extension = [ext]
 
+        session = self._make_session(self._well_known_response())
         state = self._make_state()
-        auth = FHIRAuth.from_capability_security(security, state)
+        auth = FHIRAuth.from_capability_security(security, state, session=session)
 
         self.assertIsInstance(auth, FHIROAuth2Auth)
-        mock_get.assert_not_called()
+        session.get.assert_not_called()
 
     def test_discovery_skipped_when_no_aud(self):
         """If state has no aud, .well-known should not be attempted."""
-        state = {"app_id": "test"}
+        state = {"app_id": "test", "well_known_fallback": True}
         auth = FHIRAuth.from_capability_security(None, state)
 
         self.assertNotIsInstance(auth, FHIROAuth2Auth)
 
-    @patch("fhirclient.auth.requests.get")
-    def test_discovery_strips_trailing_slash_from_aud(self, mock_get):
+    def test_discovery_strips_trailing_slash_from_aud(self):
         """Trailing slash on aud should not produce double-slash in .well-known URL."""
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = self._well_known_response()
-        mock_resp.raise_for_status = MagicMock()
-        mock_get.return_value = mock_resp
+        session = self._make_session(self._well_known_response())
 
         state = self._make_state(aud="https://fhir.example.com/api/v1/fhir/")
-        FHIRAuth.from_capability_security(None, state)
+        FHIRAuth.from_capability_security(None, state, session=session)
 
-        called_url = mock_get.call_args[0][0]
+        called_url = session.get.call_args[0][0]
         self.assertEqual(
             called_url,
             "https://fhir.example.com/api/v1/fhir/.well-known/smart-configuration",
         )
         self.assertNotIn("//.", called_url)
 
+    def test_discovery_uses_session_for_http_call(self):
+        """Discovery should use the provided session, not bare requests."""
+        session = self._make_session(self._well_known_response())
+
+        state = self._make_state()
+        FHIRAuth.from_capability_security(None, state, session=session)
+
+        session.get.assert_called_once()
+
+
+class TestWellKnownUrl(unittest.TestCase):
+    """Tests for the _well_known_url helper."""
+
+    def test_builds_url_without_trailing_slash(self):
+        url = FHIRAuth._well_known_url("https://fhir.example.com/api")
+        self.assertEqual(url, "https://fhir.example.com/api/.well-known/smart-configuration")
+
+    def test_strips_trailing_slash(self):
+        url = FHIRAuth._well_known_url("https://fhir.example.com/api/")
+        self.assertEqual(url, "https://fhir.example.com/api/.well-known/smart-configuration")
+
+    def test_strips_multiple_trailing_slashes(self):
+        url = FHIRAuth._well_known_url("https://fhir.example.com/api///")
+        self.assertEqual(url, "https://fhir.example.com/api/.well-known/smart-configuration")
+
 
 class TestWellKnownCacheInAuthorizeParams(unittest.TestCase):
     """Tests that cached .well-known config is reused in _authorize_params."""
 
-    @patch("fhirclient.auth.requests.get")
-    def test_cached_config_prevents_second_fetch(self, mock_get):
+    def test_cached_config_prevents_second_fetch(self):
         """When _well_known_config is set, _authorize_params should not re-fetch."""
         wk = {
             "authorization_endpoint": "https://fhir.example.com/oauth2/authorize",
             "token_endpoint": "https://fhir.example.com/oauth2/token",
             "code_challenge_methods_supported": ["S256"],
         }
+        session = MagicMock()
         mock_resp = MagicMock()
         mock_resp.json.return_value = wk
         mock_resp.raise_for_status = MagicMock()
-        mock_get.return_value = mock_resp
+        session.get.return_value = mock_resp
 
         state = self._make_state()
-        auth = FHIRAuth.from_capability_security(None, state)
+        auth = FHIRAuth.from_capability_security(None, state, session=session)
 
         # Reset mock to track only _authorize_params calls
-        mock_get.reset_mock()
+        session.get.reset_mock()
 
         server = MagicMock()
         server.desired_scope = "patient/*.read"
@@ -186,7 +201,7 @@ class TestWellKnownCacheInAuthorizeParams(unittest.TestCase):
         auth._authorize_params(server)
 
         # .well-known should NOT have been fetched again
-        mock_get.assert_not_called()
+        session.get.assert_not_called()
         server.request_data.assert_not_called()
 
     def _make_state(self, aud="https://fhir.example.com/api/v1/fhir"):
@@ -196,24 +211,25 @@ class TestWellKnownCacheInAuthorizeParams(unittest.TestCase):
             "app_secret": None,
             "redirect_uri": "https://example.com/callback",
             "jwt_token": None,
+
         }
 
 
 class TestWellKnownCacheNotSerialized(unittest.TestCase):
     """Test that well_known_config is excluded from serialized state."""
 
-    @patch("fhirclient.auth.requests.get")
-    def test_well_known_config_not_in_state_property(self, mock_get):
+    def test_well_known_config_not_in_state_property(self):
         """well_known_config should not appear in auth.state (write side)."""
         wk = {
             "authorization_endpoint": "https://fhir.example.com/oauth2/authorize",
             "token_endpoint": "https://fhir.example.com/oauth2/token",
             "code_challenge_methods_supported": ["S256"],
         }
+        session = MagicMock()
         mock_resp = MagicMock()
         mock_resp.json.return_value = wk
         mock_resp.raise_for_status = MagicMock()
-        mock_get.return_value = mock_resp
+        session.get.return_value = mock_resp
 
         state = {
             "aud": "https://fhir.example.com/api/v1/fhir",
@@ -221,8 +237,9 @@ class TestWellKnownCacheNotSerialized(unittest.TestCase):
             "app_secret": None,
             "redirect_uri": "https://example.com/callback",
             "jwt_token": None,
+
         }
-        auth = FHIRAuth.from_capability_security(None, state)
+        auth = FHIRAuth.from_capability_security(None, state, session=session)
 
         self.assertIsInstance(auth, FHIROAuth2Auth)
         self.assertNotIn("well_known_config", auth.state)


### PR DESCRIPTION
## Summary
- Adds fallback OAuth endpoint discovery via `.well-known/smart-configuration` when a FHIR server's CapabilityStatement has no security block (e.g. Elevance Health)
- Caches the `.well-known` response to avoid duplicate fetches in `_authorize_params()`
- Adds 9 unit tests covering discovery, error handling, caching, and guard conditions

## Context
Elevance Health's CapabilityStatement returns `security: null`, causing `from_capability_security()` to create basic `FHIRAuth` (auth_type='none') instead of `FHIROAuth2Auth`. This means no Bearer token is ever sent → HTTP 403 on all FHIR requests. Their `.well-known/smart-configuration` endpoint works correctly and returns valid OAuth endpoints.

## Test plan
- [x] Unit tests pass (`pytest tests/auth_test.py`)
- [ ] Validate end-to-end against Elevance sandbox (authorize → token exchange → FHIR data retrieval)
- [ ] Verify existing vendors (Epic, Cerner, AthenaHealth, MeldRx) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)